### PR TITLE
Injection du gestionnaire de service

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -56,3 +56,5 @@ apache_restart_state: restarted
 # Apache package state; use `present` to make sure it's installed, or `latest`
 # if you want to upgrade or switch versions using a new repo.
 apache_packages_state: present
+
+gestionnaire_service: auto

--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -3,3 +3,4 @@
   service:
     name: "{{ apache_service }}"
     state: "{{ apache_restart_state }}"
+    use: "{{ gestionnaire_service }}"

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -83,3 +83,5 @@
     name: "{{ apache_service }}"
     state: "{{ apache_state }}"
     enabled: true
+    use: "{{ gestionnaire_service }}"
+


### PR DESCRIPTION
Debian 12 est autodetecté en systemD alors que dans le docker, il n'est pas encore installé à ce moment là.

On offre la possibilité d'injecter le gestionnaire de services à utiliser.